### PR TITLE
Fix null selected values when using `as.picks`

### DIFF
--- a/R/0-as_picks.R
+++ b/R/0-as_picks.R
@@ -251,6 +251,6 @@ teal_transform_filter <- function(x, label = "Filter") {
 
 .choices_selected_to_variables <- function(x) {
   x$choices <- as.character(x$choices)
-  x$selected <- as.character(x$selected)
+  if (!is.null(x$selected)) x$selected <- as.character(x$selected)
   .select_spec_to_variables(x)
 }

--- a/tests/testthat/test-0-as_picks.R
+++ b/tests/testthat/test-0-as_picks.R
@@ -54,3 +54,25 @@ testthat::describe("as.picks doesn't convert filter_spec to picks", {
     )
   })
 })
+
+testthat::describe("as.picks converts choices selected to variables", {
+  testthat::it("works when choices and selected are not NULL", {
+    testthat::expect_s3_class(
+      as.picks(teal.transform::choices_selected(
+        selected = "# of patients",
+        choices = c("# of patients", "# of AEs")
+      )),
+      "variables"
+    )
+  })
+
+  testthat::it("works when choices and selected are not NULL", {
+    testthat::expect_s3_class(
+      as.picks(teal.transform::choices_selected(
+        selected = NULL,
+        choices = c("# of patients", "# of AEs")
+      )),
+      "variables"
+    )
+  })
+})

--- a/tests/testthat/test-0-badge_dropdown.R
+++ b/tests/testthat/test-0-badge_dropdown.R
@@ -17,7 +17,7 @@ describe("shinytest2 badge_dropdown:", {
     )
 
     app_driver <- shinytest2::AppDriver$new(app, name = "test-summary_badge") |>
-        expect_warning("may not be available when loading", fixed = TRUE)
+      expect_warning("may not be available when loading", fixed = TRUE)
     on.exit(app_driver$stop())
 
     app_driver$click(selector = "#test-inputs-summary_badge")


### PR DESCRIPTION
It fixes issue #35. The error was using `character(0)` instead of NULL, so we convert to character if the selected is not NULL.

I have added a test to verify `as.picks` works with choices selected when selected is NULL and when is non NULL.
This code now should work:

```
library(teal.transform)
devtools::load_all()

count_by_var <- choices_selected(
  selected = NULL,
  choices = c("# of patients", "# of AEs")
)

as.picks(count_by_var)
```