### PR TITLE
Only update if selection is different

### DIFF
--- a/R/0-module_picks.R
+++ b/R/0-module_picks.R
@@ -307,7 +307,8 @@ picks_srv.picks <- function(id, picks, data) {
 
     # for non-numeric
     shiny::observeEvent(input$selected_open, {
-      if (!isTRUE(input$selected_open)) {
+      # Update when closes and the input is different from what it was selected
+      if (!isTRUE(input$selected_open) && !isTRUE(all.equal(input$selected, sort(selected())))) {
         # ↓ pickerInput returns "" when nothing selected. This can cause failure during col select (x[,""])
         new_selected <- if (length(input$selected) && !identical(input$selected, "")) as.vector(input$selected)
         if (args$ordered) {

--- a/tests/testthat/test-0-module_picks.R
+++ b/tests/testthat/test-0-module_picks.R
@@ -689,6 +689,26 @@ describe("picks_srv resolves picks", {
 
 
 describe("picks_srv resolves picks interactively", {
+
+  it("opening and closing the picks don't resolve it again", {
+      test_picks <- picks(
+        datasets(choices = "iris", selected = "iris"),
+        variables(choices = tidyselect::everything(), selected = c(1L, 2L, 3L), multiple = TRUE)
+      )
+      shiny::testServer(
+        picks_srv,
+        args = list(id = "test", picks = test_picks, data = shiny::reactive(list(iris = iris))),
+        expr = {
+          original_selected <- picks_resolved()$variables$selected
+          session$setInputs("variables-selected_open" = TRUE)
+          session$setInputs("variables-selected" = original_selected)
+          expect_no_message(session$setInputs("variables-selected_open" = FALSE))
+          session$flushReact()
+          expect_identical(picks_resolved()$variables$selected, original_selected)
+        }
+      )
+  })
+
   it("change of dataset-input resolves variables", {
     test_picks <- picks(
       datasets(choices = c(mtcars = "mtcars", iris = "iris"), selected = "mtcars"),
@@ -704,6 +724,25 @@ describe("picks_srv resolves picks interactively", {
         test_picks$variables$choices <- setNames(colnames(iris), colnames(iris))
         test_picks$variables$selected <- "Sepal.Length"
         expect_identical(picks_resolved(), test_picks)
+      }
+    )
+  })
+
+  it("reversing input$selected order does not update picks_resolved", {
+    test_picks <- picks(
+      datasets(choices = "iris", selected = "iris"),
+      variables(choices = tidyselect::everything(), selected = c(1L, 2L, 3L), multiple = TRUE)
+    )
+    shiny::testServer(
+      picks_srv,
+      args = list(id = "test", picks = test_picks, data = shiny::reactive(list(iris = iris))),
+      expr = {
+
+        session$setInputs("variables-selected_open" = TRUE)
+        session$setInputs("variables-selected" = rev(original_selected))
+        expect_no_message(session$setInputs("variables-selected_open" = FALSE))
+        session$flushReact()
+        expect_identical(picks_resolved()$variables$selected, original_selected)
       }
     )
   })
@@ -1066,9 +1105,31 @@ describe("picks_srv resolves picks interactively", {
     )
   })
 
+  it("changing character slider input updates picks_resolved when needed", {
+
+    test_picks <- picks(
+      datasets("iris"),
+      variables(c("Species", "Sepal.Length"))
+    )
+
+    shiny::testServer(
+      picks_srv,
+      args = list(id = "test", picks = test_picks, data = shiny::reactive(list(iris = iris))),
+      expr = {
+        browser()
+        session$returned()
+        session$setInputs(`variables-selected` = colnames(iris)[c(1L, 3L)])
+        session$setInputs(`variables-selected_open` = FALSE) # close dropdown to trigger
+      })
+  })
+
   it("changing numeric range in slider input updates picks_resolved")
+
   it("changing integer range in slider input updates picks_resolved")
+
   it("changing date range in slider input updates picks_resolved")
+
   it("changing date range in slider input updates picks_resolved")
+
   it("setting picks_resolved$selected outside of range adjust to the available range")
 })

--- a/tests/testthat/test-0-module_picks.R
+++ b/tests/testthat/test-0-module_picks.R
@@ -689,24 +689,23 @@ describe("picks_srv resolves picks", {
 
 
 describe("picks_srv resolves picks interactively", {
-
   it("opening and closing the picks don't resolve it again", {
-      test_picks <- picks(
-        datasets(choices = "iris", selected = "iris"),
-        variables(choices = tidyselect::everything(), selected = c(1L, 2L, 3L), multiple = TRUE)
-      )
-      shiny::testServer(
-        picks_srv,
-        args = list(id = "test", picks = test_picks, data = shiny::reactive(list(iris = iris))),
-        expr = {
-          original_selected <- picks_resolved()$variables$selected
-          session$setInputs("variables-selected_open" = TRUE)
-          session$setInputs("variables-selected" = original_selected)
-          expect_no_message(session$setInputs("variables-selected_open" = FALSE))
-          session$flushReact()
-          expect_identical(picks_resolved()$variables$selected, original_selected)
-        }
-      )
+    test_picks <- picks(
+      datasets(choices = "iris", selected = "iris"),
+      variables(choices = tidyselect::everything(), selected = c(1L, 2L, 3L), multiple = TRUE)
+    )
+    shiny::testServer(
+      picks_srv,
+      args = list(id = "test", picks = test_picks, data = shiny::reactive(list(iris = iris))),
+      expr = {
+        original_selected <- picks_resolved()$variables$selected
+        session$setInputs("variables-selected_open" = TRUE)
+        session$setInputs("variables-selected" = original_selected)
+        expect_no_message(session$setInputs("variables-selected_open" = FALSE))
+        session$flushReact()
+        expect_identical(picks_resolved()$variables$selected, original_selected)
+      }
+    )
   })
 
   it("change of dataset-input resolves variables", {
@@ -1106,7 +1105,6 @@ describe("picks_srv resolves picks interactively", {
   })
 
   it("changing character slider input updates picks_resolved when needed", {
-
     test_picks <- picks(
       datasets("iris"),
       variables(c("Species", "Sepal.Length"))
@@ -1119,7 +1117,8 @@ describe("picks_srv resolves picks interactively", {
         session$returned()
         session$setInputs(`variables-selected` = colnames(iris)[c(1L, 3L)])
         session$setInputs(`variables-selected_open` = FALSE) # close dropdown to trigger
-      })
+      }
+    )
   })
 
   it("changing numeric range in slider input updates picks_resolved")

--- a/tests/testthat/test-0-module_picks.R
+++ b/tests/testthat/test-0-module_picks.R
@@ -1106,7 +1106,7 @@ describe("picks_srv resolves picks interactively", {
 
   it("changing character slider input updates picks_resolved when needed", {
     test_picks <- picks(
-      datasets("iris"),
+      datasets("iris", "iris"),
       variables(c("Species", "Sepal.Length"))
     )
 

--- a/tests/testthat/test-0-module_picks.R
+++ b/tests/testthat/test-0-module_picks.R
@@ -737,12 +737,12 @@ describe("picks_srv resolves picks interactively", {
       picks_srv,
       args = list(id = "test", picks = test_picks, data = shiny::reactive(list(iris = iris))),
       expr = {
-
+        original_selected <- picks_resolved()$variables$selected
         session$setInputs("variables-selected_open" = TRUE)
         session$setInputs("variables-selected" = rev(original_selected))
         expect_no_message(session$setInputs("variables-selected_open" = FALSE))
         session$flushReact()
-        expect_identical(picks_resolved()$variables$selected, original_selected)
+        expect_identical(picks_resolved()$variables$selected, rev(original_selected))
       }
     )
   })
@@ -1116,7 +1116,6 @@ describe("picks_srv resolves picks interactively", {
       picks_srv,
       args = list(id = "test", picks = test_picks, data = shiny::reactive(list(iris = iris))),
       expr = {
-        browser()
         session$returned()
         session$setInputs(`variables-selected` = colnames(iris)[c(1L, 3L)])
         session$setInputs(`variables-selected_open` = FALSE) # close dropdown to trigger


### PR DESCRIPTION
# Pull Request

Close #21 

Compares the input with the previous selection to decide if the picks resolution needs to be updated.
See the issue to test it an example. 


Notes:
 - `input$<ns>` seems to be ordered so we need to `sort()` the previous selection. 
 - I'm not sure if it is best to use a {shinytest2} or a `testServer()` for this.
 - It doesn't solve the issue of the warnings generated.
