### PR TITLE
Fixes incorrect warning with dynamic/eager choices

### DIFF
--- a/R/0-picks.R
+++ b/R/0-picks.R
@@ -504,11 +504,9 @@ values <- function(choices = function(x) !is.na(x),
   }
 
   # Avoid double loop with [.picks checks that would make it fail
-  previous_has_dynamic_choices <- vapply(x, FUN.VALUE = logical(1), FUN = .is_delayed)
-  previous_has_dynamic_choices[1] <- FALSE
+  previous_has_dynamic_choices <- c(FALSE, vapply(x, FUN.VALUE = logical(1), FUN = .is_delayed))
 
-  has_eager_choices <- vapply(x, function(x) !.is_delayed(x$choices), logical(1))
-
+  has_eager_choices <- c(vapply(x, Negate(function(x) .is_delayed(x$choices)), logical(1)), FALSE)
   if (any(previous_has_dynamic_choices & has_eager_choices)) {
     idx_wrong <- which(previous_has_dynamic_choices & has_eager_choices)[1]
     warning(

--- a/R/0-picks.R
+++ b/R/0-picks.R
@@ -17,7 +17,7 @@
 #' and optionally `variables()` and `values()`
 #'
 #' for `variables(...)` and `values(...)`: additional arguments delivered to `pickerInput`
-#' @param check_dataset: (`logical(1)`) whether to check that the first element of `picks` is `datasets()`.
+#' @param check_dataset (`logical(1)`) whether to check that the first element of `picks` is `datasets()`.
 #' This is useful to set to `FALSE` when creating picks objects that have a required dataset that is
 #' not selected by the user and defined in the module itself.
 #' @details

--- a/R/0-picks.R
+++ b/R/0-picks.R
@@ -17,7 +17,7 @@
 #' and optionally `variables()` and `values()`
 #'
 #' for `variables(...)` and `values(...)`: additional arguments delivered to `pickerInput`
-#' @param dataset_check: (`logical(1)`) whether to check that the first element of `picks` is `datasets()`.
+#' @param check_dataset: (`logical(1)`) whether to check that the first element of `picks` is `datasets()`.
 #' This is useful to set to `FALSE` when creating picks objects that have a required dataset that is
 #' not selected by the user and defined in the module itself.
 #' @details

--- a/R/0-picks.R
+++ b/R/0-picks.R
@@ -13,11 +13,13 @@
 #' @param fixed (`logical(1)`) selection will be fixed and not possible to change interactively.
 #' @param ordered (`logical(1)`) if the selected should follow the selection order. If `FALSE`
 #'   `selected` returned from `srv_module_input()` would be ordered according to order in `choices`.
-#' @param ... for `picks(...)`: hierarchical structure that contains `datasets()` as first element and optionally `variables()` and `values()`
+#' @param ... for `picks(...)`: hierarchical structure that contains `datasets()` as first element
+#' and optionally `variables()` and `values()`
 #'
 #' for `variables(...)` and `values(...)`: additional arguments delivered to `pickerInput`
 #' @param dataset_check: (`logical(1)`) whether to check that the first element of `picks` is `datasets()`.
-#' This is useful to set to `FALSE` when creating picks objects that have a required dataset that is not selected by the user and defined in the module itself.
+#' This is useful to set to `FALSE` when creating picks objects that have a required dataset that is
+#' not selected by the user and defined in the module itself.
 #' @details
 #' # `tidyselect` support
 #'

--- a/man/dot-pick.Rd
+++ b/man/dot-pick.Rd
@@ -27,7 +27,8 @@ Choices to be selected.}
 
 \item{fixed}{(\code{logical(1)}) selection will be fixed and not possible to change interactively.}
 
-\item{...}{for \code{picks(...)}: hierarchical structure that contains \code{datasets()} as first element and optionally \code{variables()} and \code{values()}
+\item{...}{for \code{picks(...)}: hierarchical structure that contains \code{datasets()} as first element
+and optionally \code{variables()} and \code{values()}
 
 for \code{variables(...)} and \code{values(...)}: additional arguments delivered to \code{pickerInput}}
 }

--- a/man/picks.Rd
+++ b/man/picks.Rd
@@ -34,6 +34,10 @@ and optionally \code{variables()} and \code{values()}
 
 for \code{variables(...)} and \code{values(...)}: additional arguments delivered to \code{pickerInput}}
 
+\item{check_dataset}{(\code{logical(1)}) whether to check that the first element of \code{picks} is \code{datasets()}.
+This is useful to set to \code{FALSE} when creating picks objects that have a required dataset that is
+not selected by the user and defined in the module itself.}
+
 \item{choices}{(\code{tidyselect::language} or \code{character})
 Available values to choose.}
 
@@ -46,10 +50,6 @@ Choices to be selected.}
 
 \item{ordered}{(\code{logical(1)}) if the selected should follow the selection order. If \code{FALSE}
 \code{selected} returned from \code{srv_module_input()} would be ordered according to order in \code{choices}.}
-
-\item{check_dataset:}{(\code{logical(1)}) whether to check that the first element of \code{picks} is \code{datasets()}.
-This is useful to set to \code{FALSE} when creating picks objects that have a required dataset that is
-not selected by the user and defined in the module itself.}
 }
 \description{
 Define choices and default selection for variables. \code{picks} allows app-developer to specify

--- a/man/picks.Rd
+++ b/man/picks.Rd
@@ -47,7 +47,7 @@ Choices to be selected.}
 \item{ordered}{(\code{logical(1)}) if the selected should follow the selection order. If \code{FALSE}
 \code{selected} returned from \code{srv_module_input()} would be ordered according to order in \code{choices}.}
 
-\item{dataset_check:}{(\code{logical(1)}) whether to check that the first element of \code{picks} is \code{datasets()}.
+\item{check_dataset:}{(\code{logical(1)}) whether to check that the first element of \code{picks} is \code{datasets()}.
 This is useful to set to \code{FALSE} when creating picks objects that have a required dataset that is
 not selected by the user and defined in the module itself.}
 }

--- a/man/picks.Rd
+++ b/man/picks.Rd
@@ -29,7 +29,8 @@ values(
 )
 }
 \arguments{
-\item{...}{for \code{picks(...)}: hierarchical structure that contains \code{datasets()} as first element and optionally \code{variables()} and \code{values()}
+\item{...}{for \code{picks(...)}: hierarchical structure that contains \code{datasets()} as first element
+and optionally \code{variables()} and \code{values()}
 
 for \code{variables(...)} and \code{values(...)}: additional arguments delivered to \code{pickerInput}}
 
@@ -47,7 +48,8 @@ Choices to be selected.}
 \code{selected} returned from \code{srv_module_input()} would be ordered according to order in \code{choices}.}
 
 \item{dataset_check:}{(\code{logical(1)}) whether to check that the first element of \code{picks} is \code{datasets()}.
-This is useful to set to \code{FALSE} when creating picks objects that have a required dataset that is not selected by the user and defined in the module itself.}
+This is useful to set to \code{FALSE} when creating picks objects that have a required dataset that is
+not selected by the user and defined in the module itself.}
 }
 \description{
 Define choices and default selection for variables. \code{picks} allows app-developer to specify

--- a/tests/testthat/test-0-picks.R
+++ b/tests/testthat/test-0-picks.R
@@ -59,6 +59,27 @@ describe("picks() assertions", {
       "eager"
     )
   })
+
+  it("warns when element with dynamic choices is followed by element with eager choices", {
+    expect_warning(
+      picks(
+        datasets(c("iris", "mtcars"), "mtcars"),
+        variables(c("Species")),
+        values("setosa", "setosa")
+      ),
+      "eager"
+    )
+  })
+
+  it("no warning when element with dynamic choices is last preceded by eager choices", {
+    expect_no_warning(
+      picks(
+        datasets(c("iris", "mtcars"), "mtcars"),
+        variables(c("Species"), "Species"),
+        values("setosa")
+      )
+    )
+  })
 })
 
 describe("picks() basic structure", {


### PR DESCRIPTION
# Pull Request

- fixes #55

Example below should not give a warning.

```r
teal.picks::picks(
  datasets("adsl", "adsl"),
  teal.picks::variables("PARAMCD", "PARAMCD"),
  teal.picks::values(c("AEDECOD", "AESTDTC"), multiple = TRUE)
)
```