### PR TITLE
Add articles to pkgdown and silence vignette messages

### DIFF
--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -5,8 +5,15 @@ template:
 
 navbar:
   structure:
-    left: [intro, reference, news]
+    left: [intro, reference, articles, news]
     right: [search, github]
+
+articles:
+  - title: Get started
+    navbar: Get started
+    contents:
+      - teal-picks-in-teal
+      - teal-picks-standalone-shiny
 
 reference:
   - title: Picks

--- a/vignettes/teal-picks-standalone-shiny.Rmd
+++ b/vignettes/teal-picks-standalone-shiny.Rmd
@@ -21,7 +21,7 @@ You can use `picks_ui()` and `picks_srv()` in a plain Shiny app: pass a reactive
 
 Run the `shinyApp` chunk interactively.
 
-```{r data}
+```{r data, message = FALSE}
 library(shiny)
 library(teal.data)
 library(teal.picks)


### PR DESCRIPTION
Closes #65

<img width="363" height="175" alt="image" src="https://github.com/user-attachments/assets/f5509575-7372-42ae-9cb9-45ed175cbd9b" />

I also set message to false so we don't see the extra code block when loading teal.data.

### Before:
<img width="403" height="371" alt="image" src="https://github.com/user-attachments/assets/5a698a51-40d9-4ac1-b1db-daa19addb9e3" />

### After:
<img width="371" height="240" alt="image" src="https://github.com/user-attachments/assets/cb368b88-4717-4838-9b35-bc1fd1ecf001" />
