### PR TITLE
Adds class to delayed warnings to allow for specific suppression

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,4 +49,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/R/as_picks.R
+++ b/R/as_picks.R
@@ -90,7 +90,7 @@ as.picks <- function(x, quiet = FALSE) { # nolint: object_name_linter.
 
     NULL
   } else if (!is.null(x) && !quiet) {
-    warning("'", class(x)[1], "' are not convertible to picks")
+    warning(sprintf("'%s' are not convertible to picks", class(x)[1]))
     NULL
   } else {
     NULL

--- a/R/picks.R
+++ b/R/picks.R
@@ -388,10 +388,15 @@ values <- function(choices = function(x) !is.na(x),
   is_selected_eager <- is.character(selected)
   if (is_choices_delayed && is_selected_eager) {
     warning(
-      deparse(sys.call(-1)),
-      "\n - Setting explicit `selected` while `choices` are delayed (set using `tidyselect`) doesn't ",
-      "guarantee that `selected` is a subset of `choices`.",
-      call. = FALSE
+      warningCondition(
+        paste0(
+          deparse(sys.call(-1)),
+          "\n - Setting explicit `selected` while `choices` are delayed (set using `tidyselect`) doesn't ",
+          "guarantee that `selected` is a subset of `choices`."
+        ),
+        class = c("pick_delayed", "picks_delayed"),
+        call. = FALSE
+      )
     )
   }
 
@@ -512,10 +517,16 @@ values <- function(choices = function(x) !is.na(x),
   if (any(previous_has_dynamic_choices & has_eager_choices)) {
     idx_wrong <- which(previous_has_dynamic_choices & has_eager_choices)[1]
     warning(
-      element_classes[idx_wrong], " has eager choices (character) while ",
-      element_classes[idx_wrong - 1], " has dynamic choices. ",
-      "It is not guaranteed that explicitly defined choices will be a subset of data selected in a previous element.",
-      call. = FALSE
+      warningCondition(
+        paste0(
+          element_classes[idx_wrong], " has eager choices (character) while ",
+          element_classes[idx_wrong - 1], " has dynamic choices. ",
+          "It is not guaranteed that explicitly defined choices will be a ",
+          "subset of data selected in a previous element."
+        ),
+        call. = FALSE,
+        class = "picks_delayed"
+      )
     )
   }
   TRUE

--- a/man/as.picks.Rd
+++ b/man/as.picks.Rd
@@ -21,12 +21,12 @@ teal_transform_filter(x, label = "Filter")
 Helper functions to ease transition between \code{\link[teal.transform:data_extract_spec]{teal.transform::data_extract_spec()}} and \code{\link[=picks]{picks()}}.
 }
 \details{
-With introduction of \code{\link{picks}}, \code{\link[teal.transform:data_extract_spec]{teal.transform::data_extract_spec}} will no longer serve a primary tool to
-define variable choices and default selection in teal-modules and eventually \code{\link[teal.transform:data_extract_spec]{teal.transform::data_extract_spec}}
+With introduction of \code{\link{picks}}, \code{\link[teal.transform:data_extract_spec]{data_extract_spec}} will no longer serve a primary tool to
+define variable choices and default selection in teal-modules and eventually \code{\link[teal.transform:data_extract_spec]{data_extract_spec}}
 will be deprecated.
 To ease the transition to the new tool, we provide \code{as.picks} method which can handle 1:1
-conversion from \code{\link[teal.transform:data_extract_spec]{teal.transform::data_extract_spec}} to \code{\link{picks}}. Unfortunately, when \code{\link[teal.transform:data_extract_spec]{teal.transform::data_extract_spec}}
-contains \code{\link[teal.transform:filter_spec]{teal.transform::filter_spec}} then \code{as.picks} is unable to provide reliable \code{\link{picks}} equivalent.
+conversion from \code{\link[teal.transform:data_extract_spec]{data_extract_spec}} to \code{\link{picks}}. Unfortunately, when \code{\link[teal.transform:data_extract_spec]{data_extract_spec}}
+contains \code{\link[teal.transform:filter_spec]{filter_spec}} then \code{as.picks} is unable to provide reliable \code{\link{picks}} equivalent.
 }
 \examples{
 # convert des with eager select_spec

--- a/man/resolver.Rd
+++ b/man/resolver.Rd
@@ -9,7 +9,7 @@ resolver(x, data)
 \arguments{
 \item{x}{(\code{\link[=picks]{picks()}}) settings for picks.}
 
-\item{data}{(\code{\link[teal.data:teal_data]{teal.data::teal_data()}} \code{environment} or \code{list}) any data collection supporting object extraction with \code{[[}.
+\item{data}{(\code{\link[teal.data:teal_data]{teal_data()}} \code{environment} or \code{list}) any data collection supporting object extraction with \code{[[}.
 Used to determine values of unresolved \code{picks}.}
 }
 \value{

--- a/man/tm_merge.Rd
+++ b/man/tm_merge.Rd
@@ -16,7 +16,7 @@ For \code{modules()} defaults to \code{"root"}. See \code{Details}.}
 To learn more check \code{vignette("transform-input-data", package = "teal")}.}
 }
 \description{
-Example \code{\link[teal:teal_modules]{teal::module}} containing interactive inputs and displaying results of merge.
+Example \code{\link[teal:module]{teal::module}} containing interactive inputs and displaying results of merge.
 }
 \examples{
 library(teal)


### PR DESCRIPTION
# Pull Request

<!-- Please describe your pull request here -->

Simple addition that enhances the `warning` call to allow to suppress warnings when needed (let's say in tests on `tmc` and `tmg`).

Alternatively, we could transform these into messages, as warning seems too strict.

For instance, an example on `tmc`:

```r
paramcd = picks(
  variables("PARAMCD", "PARAMCD"),
  values(selected = "FKSI-FWB", multiple = FALSE),
  check_dataset = FALSE
)
#> Warning message:
#> values(selected = "FKSI-FWB", multiple = FALSE)
#>  - Setting explicit `selected` while `choices` are delayed (set using `tidyselect`) doesn't guarantee that `selected` is a subset of `choices`. 
#>  <picks>
#>    <variables>:
#>      choices: PARAMCD
#>      selected: PARAMCD
#>      multiple=FALSE, ordered=FALSE, fixed=TRUE, allow-clear=FALSE
#>    <values>:
#>      choices: <fn>
#>      selected: FKSI-FWB
#>      multiple=FALSE, ordered=FALSE, fixed=FALSE

picks(
  variables("PARAMCD", "PARAMCD"),
  values(selected = "FKSI-FWB", multiple = FALSE),
  check_dataset = FALSE
) |> suppressWarnings(classes = c("picks_delayed"))
#>  <picks>
#>    <variables>:
#>      choices: PARAMCD
#>      selected: PARAMCD
#>      multiple=FALSE, ordered=FALSE, fixed=TRUE, allow-clear=FALSE
#>    <values>:
#>      choices: <fn>
#>      selected: FKSI-FWB
#>      multiple=FALSE, ordered=FALSE, fixed=FALSE
```