### PR TITLE
Fix CSS load when we use only fixed picks UI container

### DIFF
--- a/R/module_picks.R
+++ b/R/module_picks.R
@@ -59,20 +59,25 @@ picks_ui.picks <- function(id, picks, container) {
   ns <- shiny::NS(id)
   badge_label <- shiny::uiOutput(ns("summary"), container = htmltools::tags$span)
   content <- lapply(picks, function(x) .pick_ui(id = ns(methods::is(x))))
-  htmltools::tags$div(
-    if (missing(container)) {
-      if (all(vapply(picks, is_pick_fixed, logical(1)))) {
-        fixed_picks(id = ns("inputs"), badge_label)
-      } else {
-        badge_dropdown(id = ns("inputs"), label = badge_label, htmltools::tagList(content))
-      }
-    } else {
-      if (!any(sapply(htmltools::tags, identical, container))) {
-        stop("Container should be one of `htmltools::tags`")
-      }
-      container(content)
+  if (missing(container)) {
+    htmltools::tagList(
+      htmltools::singleton(htmltools::tags$head(
+        htmltools::includeCSS(system.file("badge-dropdown", "style.css", package = "teal.picks"))
+      )),
+      htmltools::tags$div(
+        if (all(vapply(picks, is_pick_fixed, logical(1)))) {
+          fixed_picks(id = ns("inputs"), badge_label)
+        } else {
+          badge_dropdown(id = ns("inputs"), label = badge_label, htmltools::tagList(content))
+        }
+      )
+    )
+  } else {
+    if (!any(sapply(htmltools::tags, identical, container))) {
+      stop("Container should be one of `htmltools::tags`")
     }
-  )
+    htmltools::tags$div(container(content))
+  }
 }
 
 #' @rdname picks_module

--- a/R/module_picks.R
+++ b/R/module_picks.R
@@ -60,17 +60,12 @@ picks_ui.picks <- function(id, picks, container) {
   badge_label <- shiny::uiOutput(ns("summary"), container = htmltools::tags$span)
   content <- lapply(picks, function(x) .pick_ui(id = ns(methods::is(x))))
   if (missing(container)) {
-    htmltools::tagList(
-      htmltools::singleton(htmltools::tags$head(
-        htmltools::includeCSS(system.file("badge-dropdown", "style.css", package = "teal.picks"))
-      )),
-      htmltools::tags$div(
-        if (all(vapply(picks, is_pick_fixed, logical(1)))) {
-          fixed_picks(id = ns("inputs"), badge_label)
-        } else {
-          badge_dropdown(id = ns("inputs"), label = badge_label, htmltools::tagList(content))
-        }
-      )
+    htmltools::tags$div(
+      if (all(vapply(picks, is_pick_fixed, logical(1)))) {
+        badge_fixed(id = ns("inputs"), badge_label)
+      } else {
+        badge_dropdown(id = ns("inputs"), label = badge_label, htmltools::tagList(content))
+      }
     )
   } else {
     if (!any(sapply(htmltools::tags, identical, container))) {

--- a/R/ui_containers.R
+++ b/R/ui_containers.R
@@ -13,7 +13,6 @@ badge_dropdown <- function(id, label, content) {
   ns <- shiny::NS(id)
   htmltools::tagList(
     htmltools::singleton(htmltools::tags$head(
-      htmltools::includeCSS(system.file("badge-dropdown", "style.css", package = "teal.picks")),
       htmltools::includeScript(system.file("badge-dropdown", "script.js", package = "teal.picks"))
     )),
     htmltools::tags$div(

--- a/R/ui_containers.R
+++ b/R/ui_containers.R
@@ -13,6 +13,7 @@ badge_dropdown <- function(id, label, content) {
   ns <- shiny::NS(id)
   htmltools::tagList(
     htmltools::singleton(htmltools::tags$head(
+      htmltools::includeCSS(system.file("badge-dropdown", "style.css", package = "teal.picks")),
       htmltools::includeScript(system.file("badge-dropdown", "script.js", package = "teal.picks"))
     )),
     htmltools::tags$div(
@@ -51,13 +52,18 @@ badge_dropdown <- function(id, label, content) {
 #' @param label (`shiny.tag`) Label displayed on the component
 #' @keywords internal
 #' @noRd
-fixed_picks <- function(id, label) {
+badge_fixed <- function(id, label) {
   ns <- shiny::NS(id)
 
-  htmltools::tags$div(
-    id = ns("fixed_picks_badge"),
-    class = "fixed-picks",
-    htmltools::tags$label(label),
-    htmltools::tags$i(bsicons::bs_icon("lock-fill"))
+  htmltools::tagList(
+    htmltools::singleton(htmltools::tags$head(
+      htmltools::includeCSS(system.file("badge-dropdown", "style.css", package = "teal.picks"))
+    )),
+    htmltools::tags$div(
+      id = ns("fixed_badge"),
+      class = "fixed-picks",
+      htmltools::tags$label(label),
+      htmltools::tags$i(bsicons::bs_icon("lock-fill"))
+    )
   )
 }


### PR DESCRIPTION
This is fixing this issue #75 

Please compare the screenshot in the issue with this branch. You can try this example:

```
library("teal")
devtools::load_all()

# --- Custom dummy teal module using a single fixed picks object ---

ui_dummy <- function(id, var_picks, ...) {
  ns <- shiny::NS(id)
  shiny::tagList(
    teal.widgets::standard_layout(
      output = shiny::verbatimTextOutput(ns("out")),
      encoding = shiny::tags$div(
        shiny::tags$label("Encodings", class = "text-primary"),
        shiny::tags$div(
          shiny::tags$strong("Variable"),
          teal.picks::picks_ui(id = ns("var"), picks = var_picks)
        )
      )
    )
  )
}

srv_dummy <- function(id, data, dataname, var_picks) {
  checkmate::assert_class(data, "reactive")
  shiny::moduleServer(id, function(input, output, session) {
    selectors <- teal.picks::picks_srv(
      picks = list(var = var_picks),
      data = data
    )

    merged <- teal.picks::merge_srv(
      id = "merge",
      data = data,
      selectors = selectors,
      output_name = "ANL"
    )

    output$out <- shiny::renderPrint({
      selected_var <- merged$variables()$var
      anl <- merged$data()[["ANL"]]
      cat("Selected variable:", selected_var, "\n")
      print(head(anl[[selected_var]]))
    })
  })
}

tm_dummy <- function(label, dataname,
                     var_picks = teal.picks::variables(
                       choices = "ADY",
                       selected = "ADY",
                       fixed = TRUE
                     )) {
  var_picks <- teal.picks::picks(teal.picks::datasets(dataname), var_picks)
  teal::module(
    label = label,
    datanames = dataname,
    ui = ui_dummy,
    ui_args = list(var_picks = var_picks),
    server = srv_dummy,
    server_args = list(dataname = dataname, var_picks = var_picks)
  )
}

# --- App ---

data <- teal_data() %>%
  within({
    ADTR <- teal.data::rADTR
  })

join_keys(data) <- default_cdisc_join_keys[names(data)]

app <- init(
  data = data,
  modules = modules(
    tm_dummy(
      label = "Dummy module (fixed picks)",
      dataname = "ADTR"
    )
  )
)

shinyApp(app$ui, app$server)

```
The fix consisted on loading the css differently. Previously, the CSS was being loaded only when we used the clickable badge dropdown. Now, if the developer does not provide a custom container, we load the css regardless of using fixed or clickable picks UI.

<img width="1035" height="496" alt="image" src="https://github.com/user-attachments/assets/070c3f2e-ae6a-4cab-a825-8c39f83c65f1" />

See that the styling is correct now