### PR TITLE
chore: improve README style

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ VignetteBuilder:
     knitr
 Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
+Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 Language: en-US
 LazyData: true

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@
 `teal.picks` is an `R` package used in the development of [`teal`](https://insightsengineering.github.io/teal/) applications. It provides:
 
 - a hierarchical **choices / selected** model for datasets, variables, and values in a Shiny session, with optional **tidyselect** support for dynamic choices,
-- **`picks_ui`** and **`picks_srv`** modules to collect those selections interactively,
-- **`merge_srv`** and **`tm_merge`** to merge `teal` data according to user picks,
-- conversion helpers such as **`as.picks`** to align with **`teal.transform`** objects.
+- `picks_ui` and `picks_srv` modules to collect those selections interactively,
+- `merge_srv` and `tm_merge` to merge `teal` data according to user picks,
+- conversion helpers such as `as.picks` to align with `teal.transform` objects.
 
 ## Installation
 
@@ -63,7 +63,7 @@ my_picks <- picks(
 )
 ```
 
-Wire `my_picks` into **`picks_ui`** / **`picks_srv`** with a reactive `teal_data` object, or use **`tm_merge`** inside a **`teal::init()`** application. Full patterns are documented on the package site.
+Wire `my_picks` into `picks_ui` / `picks_srv` with a reactive `teal_data` object, or use `tm_merge` inside a `teal::init()` application. Full patterns are documented on the package site.
 
 ## Getting help
 

--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -1,7 +1,7 @@
 url: https://insightsengineering.github.io/teal.picks/
 
 template:
-  bootstrap: 5
+  package: nesttemplate
 
 navbar:
   structure:


### PR DESCRIPTION
A simple cosmetic change. The README contained code in the style **`my_code`** but the rest of teal README contain the more usual `my_code`. This changes the style pattern to the more normal one, which I also like more. View the README to review it.
