### PR TITLE
Revert to `visibility` css property and allows fixed picks to show error

### DIFF
--- a/R/module_picks.R
+++ b/R/module_picks.R
@@ -59,20 +59,25 @@ picks_ui.picks <- function(id, picks, container) {
   ns <- shiny::NS(id)
   badge_label <- shiny::uiOutput(ns("summary"), container = htmltools::tags$span)
   content <- lapply(picks, function(x) .pick_ui(id = ns(methods::is(x))))
-  htmltools::tags$div(
-    if (missing(container)) {
-      if (all(vapply(picks, is_pick_fixed, logical(1)))) {
-        fixed_picks(id = ns("inputs"), badge_label)
-      } else {
-        badge_dropdown(id = ns("inputs"), label = badge_label, htmltools::tagList(content))
-      }
-    } else {
-      if (!any(sapply(htmltools::tags, identical, container))) {
-        stop("Container should be one of `htmltools::tags`")
-      }
-      container(content)
+  if (missing(container)) {
+    htmltools::tagList(
+      htmltools::singleton(htmltools::tags$head(
+        htmltools::includeCSS(system.file("badge-dropdown", "style.css", package = "teal.picks"))
+      )),
+      htmltools::tags$div(
+        if (all(vapply(picks, is_pick_fixed, logical(1)))) {
+          fixed_picks(id = ns("inputs"), badge_label)
+        } else {
+          badge_dropdown(id = ns("inputs"), label = badge_label, htmltools::tagList(content))
+        }
+      )
+    )
+  } else {
+    if (!any(sapply(htmltools::tags, identical, container))) {
+      stop("Container should be one of `htmltools::tags`")
     }
-  )
+    htmltools::tags$div(container(content))
+  }
 }
 
 #' @rdname picks_module

--- a/R/module_picks.R
+++ b/R/module_picks.R
@@ -62,7 +62,7 @@ picks_ui.picks <- function(id, picks, container) {
   if (missing(container)) {
     htmltools::tags$div(
       if (all(vapply(picks, is_pick_fixed, logical(1)))) {
-        badge_fixed(id = ns("inputs"), badge_label)
+        badge_fixed(id = ns("inputs"), badge_label, htmltools::tagList(content))
       } else {
         badge_dropdown(id = ns("inputs"), label = badge_label, htmltools::tagList(content))
       }
@@ -182,6 +182,7 @@ picks_srv.picks <- function(id, picks, data) {
 
         args <- attributes(picks[[slot_name]])
         args <- args[!names(args) %in% c("names", "class")]
+
         .pick_srv(
           id = slot_name,
           pick_type = slot_name,
@@ -254,7 +255,7 @@ picks_srv.picks <- function(id, picks, data) {
       .validate_is_eager(choices())
       .validate_is_eager(selected())
       if (!length(choices()) || isTRUE(args$fixed)) {
-        NULL
+        .pick_ui_fixed(session$ns("selected"), selected())
       } else if (.is_ranged(choices()) && inherits(choices(), "Date")) {
         .pick_ui_date(
           session$ns("range"),
@@ -290,7 +291,7 @@ picks_srv.picks <- function(id, picks, data) {
           args = args[!names(args) %in% c("multiple")]
         )
       }
-    }) |> bindEvent(choices()) # never change on selected()
+    }) |> bindEvent(choices(), ignoreNULL = FALSE) # never change on selected()
 
     # for numeric / date / posixct range
     range_debounced <- shiny::reactive(input$range) |> debounce(1000)
@@ -321,6 +322,17 @@ picks_srv.picks <- function(id, picks, data) {
     })
     selected
   })
+}
+
+.pick_ui_fixed <- function(id, selected) {
+  htmltools::tags$div(
+    class = "form-group shiny-input-container",
+    htmltools::tags$input(
+      id = id,
+      # disabled = "disabled",
+      value = selected
+    )
+  )
 }
 
 .pick_ui_date <- function(id, label, choices, selected, args) {

--- a/R/module_picks.R
+++ b/R/module_picks.R
@@ -329,7 +329,7 @@ picks_srv.picks <- function(id, picks, data) {
     class = "form-group shiny-input-container",
     htmltools::tags$input(
       id = id,
-      # disabled = "disabled",
+      disabled = "disabled",
       value = selected
     )
   )

--- a/R/module_picks.R
+++ b/R/module_picks.R
@@ -60,17 +60,12 @@ picks_ui.picks <- function(id, picks, container) {
   badge_label <- shiny::uiOutput(ns("summary"), container = htmltools::tags$span)
   content <- lapply(picks, function(x) .pick_ui(id = ns(methods::is(x))))
   if (missing(container)) {
-    htmltools::tagList(
-      htmltools::singleton(htmltools::tags$head(
-        htmltools::includeCSS(system.file("badge-dropdown", "style.css", package = "teal.picks"))
-      )),
-      htmltools::tags$div(
-        if (all(vapply(picks, is_pick_fixed, logical(1)))) {
-          fixed_picks(id = ns("inputs"), badge_label)
-        } else {
-          badge_dropdown(id = ns("inputs"), label = badge_label, htmltools::tagList(content))
-        }
-      )
+    htmltools::tags$div(
+      if (all(vapply(picks, is_pick_fixed, logical(1)))) {
+        badge_fixed(id = ns("inputs"), badge_label)
+      } else {
+        badge_dropdown(id = ns("inputs"), label = badge_label, htmltools::tagList(content))
+      }
     )
   } else {
     if (!any(sapply(htmltools::tags, identical, container))) {

--- a/R/ui_containers.R
+++ b/R/ui_containers.R
@@ -13,7 +13,6 @@ badge_dropdown <- function(id, label, content) {
   ns <- shiny::NS(id)
   htmltools::tagList(
     htmltools::singleton(htmltools::tags$head(
-      htmltools::includeCSS(system.file("badge-dropdown", "style.css", package = "teal.picks")),
       htmltools::includeScript(system.file("badge-dropdown", "script.js", package = "teal.picks"))
     )),
     htmltools::tags$div(

--- a/R/ui_containers.R
+++ b/R/ui_containers.R
@@ -13,6 +13,7 @@ badge_dropdown <- function(id, label, content) {
   ns <- shiny::NS(id)
   htmltools::tagList(
     htmltools::singleton(htmltools::tags$head(
+      htmltools::includeCSS(system.file("badge-dropdown", "style.css", package = "teal.picks")),
       htmltools::includeScript(system.file("badge-dropdown", "script.js", package = "teal.picks"))
     )),
     htmltools::tags$div(
@@ -51,13 +52,18 @@ badge_dropdown <- function(id, label, content) {
 #' @param label (`shiny.tag`) Label displayed on the component
 #' @keywords internal
 #' @noRd
-fixed_picks <- function(id, label) {
+badge_fixed <- function(id, label) {
   ns <- shiny::NS(id)
 
-  htmltools::tags$div(
-    id = ns("fixed_picks_badge"),
-    class = "fixed-picks",
-    htmltools::tags$label(label),
-    htmltools::tags$i(bsicons::bs_icon("lock-fill"))
+  htmltools::tagList(
+    htmltools::singleton(htmltools::tags$head(
+      htmltools::includeCSS(system.file("badge-dropdown", "style.css", package = "teal.picks"))
+    )),
+    htmltools::tags$div(
+      id = ns("fixed_badge"),
+      class = "fixed-picks",
+      htmltools::tags$label(label),
+      htmltools::tags$i(bsicons::bs_icon("lock-fill"))
+    )
   )
 }

--- a/R/ui_containers.R
+++ b/R/ui_containers.R
@@ -30,7 +30,8 @@ badge_dropdown <- function(id, label, content) {
         content,
         id = ns("inputs_container"),
         style = htmltools::css(
-          display = "none",
+          visibility = "hidden",
+          width = "0",
           position = "absolute",
           background = "white",
           border = "1px solid #ccc",
@@ -52,7 +53,7 @@ badge_dropdown <- function(id, label, content) {
 #' @param label (`shiny.tag`) Label displayed on the component
 #' @keywords internal
 #' @noRd
-badge_fixed <- function(id, label) {
+badge_fixed <- function(id, label, content) {
   ns <- shiny::NS(id)
 
   htmltools::tagList(
@@ -60,10 +61,17 @@ badge_fixed <- function(id, label) {
       htmltools::includeCSS(system.file("badge-dropdown", "style.css", package = "teal.picks"))
     )),
     htmltools::tags$div(
-      id = ns("fixed_badge"),
-      class = "fixed-picks",
-      htmltools::tags$label(label),
-      htmltools::tags$i(bsicons::bs_icon("lock-fill"))
+      htmltools::tags$span(
+        id = ns("fixed_badge"),
+        class = "fixed-picks badge-dropdown",
+        htmltools::tags$label(label),
+        htmltools::tags$i(bsicons::bs_icon("lock-fill"))
+      ),
+      htmltools::tags$div(
+        id = ns("inputs_container"),
+        content,
+        style = "visibility: hidden; width: 0; height: 0;"
+      )
     )
   )
 }

--- a/inst/badge-dropdown/script.js
+++ b/inst/badge-dropdown/script.js
@@ -6,7 +6,8 @@ function toggleBadgeDropdown(summaryId, containerId) {
     container.style.opacity = '0';
     container.addEventListener('transitionend', function onHidden() {
       container.removeEventListener('transitionend', onHidden);
-      container.style.display = 'none';
+      container.style.visibility = 'hidden';
+      container.style.width = "0";
       $(container).trigger('hidden');
       if (container._originalParent) {
         container._originalParent.appendChild(container);
@@ -14,7 +15,7 @@ function toggleBadgeDropdown(summaryId, containerId) {
     });
   }
 
-  if (container.style.display === 'none' || container.style.display === '') {
+  if (container.style.visibility === 'hidden' || container.style.visibility === '') {
     // Record original parent before moving to body
     if (!container._originalParent) {
       container._originalParent = container.parentNode;
@@ -29,7 +30,8 @@ function toggleBadgeDropdown(summaryId, containerId) {
     document.body.appendChild(container);
 
     container.style.opacity = '0';
-    container.style.display = 'block';
+    container.style.visibility = 'visible';
+    container.style.width = "auto";
 
     // Force reflow so the browser registers opacity: 0 before transitioning to 1
     container.getBoundingClientRect();


### PR DESCRIPTION
# Pull Request

Note for reviewer:
- It adds a manual generated text input with disabled property for it to trick `validate_input` to think it exists
- it should not affect any of the shiny reactivity, but please take this into account.

### Changes description

- Using `display: none` for the popup hides the input from `shiny` which can have adverse effects
  - Some errors were delayed because of this
  - In theory we can now use the input to trigger change in `shinytest2`
  - Visual glitch no longer exists as width is set to `0` (zero)
- Fixed picks were not showing error as they didn't generate inputs for the CSS red border rule to activate

<img width="838" height="700" alt="image" src="https://github.com/user-attachments/assets/20ee21a7-99ae-4c32-ad78-aeb7ad77b4d2" />


### Example app

Note. please use picks branch `279-interactive_variables@main` from `teal.modules.clinical`

```r
# Patient Profile Vitals - original (choices_selected) implementation

pkgload::load_all("../teal.logger", export_all = FALSE)
pkgload::load_all("../teal.code", export_all = FALSE)
pkgload::load_all("../teal.data", export_all = FALSE)
pkgload::load_all("../teal.widgets", export_all = FALSE)
pkgload::load_all("../teal.transform", export_all = FALSE)
pkgload::load_all("../teal.reporter", export_all = FALSE)
pkgload::load_all("../teal.slice", export_all = FALSE)
pkgload::load_all("../teal.picks", export_all = FALSE)
pkgload::load_all("../teal", export_all = FALSE)
pkgload::load_all("../teal.modules.clinical", export_all = FALSE)

library(nestcolor)

data <- teal_data()
data <- within(data, {
  library(dplyr)
  ADSL <- teal.modules.clinical::tmc_ex_adsl
  ADVS <- teal.modules.clinical::tmc_ex_advs
})
join_keys(data) <- default_cdisc_join_keys[names(data)]

ADSL <- data[["ADSL"]]
ADVS <- data[["ADVS"]]

app <- init(
  data = data,
  modules = modules(
    tm_g_pp_vitals(
      label = "Vitals",
      dataname = "ADVS",
      parentname = "ADSL",
      patient_col = "USUBJID",
      plot_height = c(600L, 200L, 2000L),
      paramcd = teal.picks::variables("PARAMCD", multiple = FALSE, fixed = FALSE),
      xaxis = teal.picks::variables("ADY", multiple = FALSE, fixed = FALSE),
      aval_var = picks(
        teal.picks::variables(c("AAVAL"), selected = "AAVAL", multiple = TRUE, fixed = TRUE),
        check_dataset = FALSE
      )
    ),
    tm_g_pp_vitals(
      label = "Vitals (legacy)",
      dataname = "ADVS",
      parentname = "ADSL",
      patient_col = "USUBJID",
      plot_height = c(600L, 200L, 2000L),
      paramcd = choices_selected(
        choices = variable_choices(ADVS, "PARAMCD"),
        selected = "PARAMCD"
      ),
      xaxis = choices_selected(
        choices = variable_choices(ADVS, "ADY"),
        selected = "ADY"
      ),
      aval_var = choices_selected(
        choices = variable_choices(ADVS, "AVAL"),
        selected = "AVAL"
      )
    )
  )
) |> shiny::runApp()
```