### PR TITLE
remove testthat prefix from badge dropdown test

### DIFF
--- a/tests/testthat/test-badge_dropdown.R
+++ b/tests/testthat/test-badge_dropdown.R
@@ -23,13 +23,13 @@ testthat::describe("shinytest2 badge_dropdown:", {
     on.exit(app_driver$stop())
 
     app_driver$click(selector = "#test-inputs-summary_badge")
-    testthat::expect_visible("#test-inputs-inputs_container", app_driver = app_driver)
+    expect_visible("#test-inputs-inputs_container", app_driver = app_driver)
     app_driver$click(selector = "#test-inputs-summary_badge")
-    testthat::expect_hidden("#test-inputs-inputs_container", app_driver = app_driver)
+    expect_hidden("#test-inputs-inputs_container", app_driver = app_driver)
 
     app_driver$click(selector = "#test-inputs-summary_badge")
-    testthat::expect_visible("#test-inputs-inputs_container", app_driver = app_driver)
+    expect_visible("#test-inputs-inputs_container", app_driver = app_driver)
     app_driver$click(selector = "#random")
-    testthat::expect_hidden("#test-inputs-inputs_container", app_driver = app_driver)
+    expect_hidden("#test-inputs-inputs_container", app_driver = app_driver)
   })
 })


### PR DESCRIPTION
Fix #80 

Remove testthat prefix so it can use the package version of expect_visible. 