### PR TITLE
merge_srv fix for module that pairs merge$data() with merge$variables()

### DIFF
--- a/R/module_merge.R
+++ b/R/module_merge.R
@@ -222,16 +222,13 @@ merge_srv <- function(id,
       )
     })
 
-    variables_selected <- shiny::eventReactive(
-      selectors_unwrapped(),
-      {
-        shiny::req(selectors_unwrapped())
-        lapply(
-          .merge_summary_list(selectors_unwrapped(), join_keys = teal.data::join_keys(data()))$mapping,
-          function(selector) unname(selector$variables)
-        )
-      }
-    )
+    variables_selected <- shiny::reactive({
+      shiny::req(data(), selectors_unwrapped())
+      lapply(
+        .merge_summary_list(selectors_unwrapped(), join_keys = teal.data::join_keys(data()))$mapping,
+        function(selector) unname(selector$variables)
+      )
+    })
 
     list(data = data_r, variables = variables_selected)
   })


### PR DESCRIPTION
Discovered at teal.modules.clinical at `279-interactive_variables@main` branch at CI/CD failuers https://github.com/insightsengineering/teal.modules.clinical/actions/runs/25669146947/job/75349459478?pr=1470
at `test-shinytest2-tm_t_pp_laboratory.R` file

Motivation

`merge_srv` exposed merged column names through `variables_selected`, which was implemented as `eventReactive(selectors_unwrapped(), …)`. The body of that expression also calls `teal.data::join_keys(data())`, but `eventReactive` only invalidates when its first argument changes. As a result, when the incoming `teal_data` reactive updates while pick selections stay the same (e.g. after filtering or other upstream data changes), the merged dataset reactive (`data_r`) can refresh while `variables()` still returns a stale mapping. Any module that pairs `merge$data()` with `merge$variables()` to build analysis or UI code can then see column names that no longer match the merged frame.