### PR TITLE
Allows `allow-clear` option to be set in `variables()` without being overwriten

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # teal.picks 0.1.0.9000
 
+### Miscellaneous
+
+* `variables()` allows for custom `allow-clear` options to be set by user without being overwritten.
+
 # teal.picks 0.1.0
 
 ### New Features

--- a/R/picks.R
+++ b/R/picks.R
@@ -309,7 +309,7 @@ variables <- function(choices = tidyselect::everything(),
     fixed <- !(.is_tidyselect(choices) || .is_predicate(choices)) && length(choices) == 1
   }
 
-  # allow-clear is an option available from bootstrap-select v1.14.0-beta3 and upwards hat is used by shinywidgets
+  # allow-clear is an option available from bootstrap-select v1.14.0-beta3 and upwards that is used by shinywidgets
   # Defaults to the calculated value when not explicitly provided.
   allow_clear <- !.is_tidyselect(selected) && !.is_predicate(selected) && (is.null(selected) || multiple)
   dots <- rlang::dots_list(...)

--- a/R/picks.R
+++ b/R/picks.R
@@ -310,7 +310,7 @@ variables <- function(choices = tidyselect::everything(),
   }
 
   # allow-clear is an option available from bootstrap-select v1.14.0-beta3 and upwards hat is used by shinywidgets
-  # which has a calculated default if not directly set by the user.
+  # Defaults to the calculated value when not explicitly provided.
   allow_clear <- !.is_tidyselect(selected) && !.is_predicate(selected) && (is.null(selected) || multiple)
   dots <- rlang::dots_list(...)
   if (!any(names(dots) == "allow-clear")) {

--- a/R/picks.R
+++ b/R/picks.R
@@ -16,7 +16,9 @@
 #' @param ... for `picks(...)`: hierarchical structure that contains `datasets()` as first element
 #'  and optionally `variables()` and `values()`
 #'
-#' for `variables(...)` and `values(...)`: additional arguments delivered to `pickerInput`
+#' for `variables(...)` and `values(...)`: additional arguments delivered to `pickerInput`,
+#' see [shinyWidgets::pickerOptions()] for available options as well as documentation for `bootstrap-select`
+#' `v1.14.0-beta3` or higher for newer options (e.g., `allow-clear` that allows clearing the selection).
 #' @param check_dataset (`logical(1)`) whether to check that the first element of `picks` is `datasets()`.
 #' This is useful to set to `FALSE` when creating picks objects that have a required dataset that is not
 #'  selected by the user and defined in the module itself.
@@ -307,14 +309,26 @@ variables <- function(choices = tidyselect::everything(),
     fixed <- !(.is_tidyselect(choices) || .is_predicate(choices)) && length(choices) == 1
   }
 
-  out <- .pick(
-    choices = if (.is_tidyselect(choices)) rlang::enquo(choices) else choices,
-    selected = if (.is_tidyselect(selected)) rlang::enquo(selected) else selected,
-    multiple = multiple,
-    fixed = fixed,
-    ordered = ordered,
-    `allow-clear` = !.is_tidyselect(selected) && !.is_predicate(selected) && (is.null(selected) || multiple),
-    ...
+  # allow-clear is an option available from bootstrap-select v1.14.0-beta3 and upwards hat is used by shinywidgets
+  # which has a calculated default if not directly set by the user.
+  allow_clear <- !.is_tidyselect(selected) && !.is_predicate(selected) && (is.null(selected) || multiple)
+  dots <- rlang::dots_list(...)
+  if (!any(names(dots) == "allow-clear")) {
+    dots <- c(dots, `allow-clear` = allow_clear)
+  }
+
+  out <- do.call(
+    .pick,
+    c(
+      list(
+        choices = if (.is_tidyselect(choices)) rlang::enquo(choices) else choices,
+        selected = if (.is_tidyselect(selected)) rlang::enquo(selected) else selected,
+        multiple = multiple,
+        fixed = fixed,
+        ordered = ordered
+      ),
+      dots
+    )
   )
   class(out) <- c("variables", class(out))
   out

--- a/man/dot-pick.Rd
+++ b/man/dot-pick.Rd
@@ -30,7 +30,9 @@ Choices to be selected.}
 \item{...}{for \code{picks(...)}: hierarchical structure that contains \code{datasets()} as first element
 and optionally \code{variables()} and \code{values()}
 
-for \code{variables(...)} and \code{values(...)}: additional arguments delivered to \code{pickerInput}}
+for \code{variables(...)} and \code{values(...)}: additional arguments delivered to \code{pickerInput},
+see \code{\link[shinyWidgets:pickerOptions]{shinyWidgets::pickerOptions()}} for available options as well as documentation for \code{bootstrap-select}
+\code{v1.14.0-beta3} or higher for newer options (e.g., \code{allow-clear} that allows clearing the selection).}
 }
 \value{
 \code{pick} generic object that is used by \code{\link[=datasets]{datasets()}}, \code{\link[=variables]{variables()}} and \code{\link[=values]{values()}}

--- a/man/picks.Rd
+++ b/man/picks.Rd
@@ -32,7 +32,9 @@ values(
 \item{...}{for \code{picks(...)}: hierarchical structure that contains \code{datasets()} as first element
 and optionally \code{variables()} and \code{values()}
 
-for \code{variables(...)} and \code{values(...)}: additional arguments delivered to \code{pickerInput}}
+for \code{variables(...)} and \code{values(...)}: additional arguments delivered to \code{pickerInput},
+see \code{\link[shinyWidgets:pickerOptions]{shinyWidgets::pickerOptions()}} for available options as well as documentation for \code{bootstrap-select}
+\code{v1.14.0-beta3} or higher for newer options (e.g., \code{allow-clear} that allows clearing the selection).}
 
 \item{check_dataset}{(\code{logical(1)}) whether to check that the first element of \code{picks} is \code{datasets()}.
 This is useful to set to \code{FALSE} when creating picks objects that have a required dataset that is not

--- a/tests/testthat/test-picks.R
+++ b/tests/testthat/test-picks.R
@@ -434,6 +434,16 @@ testthat::describe("variables() allow-clear attribute", {
     result <- variables(choices = c("a", "b", "c"), selected = c(1L, 2L))
     testthat::expect_false(attr(result, "allow-clear"))
   })
+
+  it("sets allow-clear manually to TRUE", {
+    result <- variables(choices = c("a", "b", "c"), selected = c(1L, 2L), "allow-clear" = TRUE)
+    testthat::expect_true(attr(result, "allow-clear"))
+  })
+
+  it("sets allow-clear manually to FALSE", {
+    result <- variables(choices = c("a", "b", "c"), selected = c(1L, 2L), "allow-clear" = FALSE)
+    testthat::expect_false(attr(result, "allow-clear"))
+  })
 })
 
 testthat::describe("variables() attribute interactions", {


### PR DESCRIPTION
# Pull Request

- Fixes #89 

### Changes description

- Only sets calculated default value if option is not present in `...`
- Updates documentation
- Updates `NEWS.md`