### PR TITLE
Fix merge_srv keys assignment

### DIFF
--- a/R/module_merge.R
+++ b/R/module_merge.R
@@ -230,7 +230,8 @@ merge_srv <- function(id,
           .merge_summary_list(
             selectors_unwrapped(),
             join_keys = teal.data::join_keys(data()),
-            output_name = output_name)$mapping,
+            output_name = output_name
+          )$mapping,
           function(selector) unname(selector$variables)
         )
       }

--- a/R/module_merge.R
+++ b/R/module_merge.R
@@ -227,7 +227,10 @@ merge_srv <- function(id,
       {
         shiny::req(selectors_unwrapped())
         lapply(
-          .merge_summary_list(selectors_unwrapped(), join_keys = teal.data::join_keys(data()))$mapping,
+          .merge_summary_list(
+            selectors_unwrapped(),
+            join_keys = teal.data::join_keys(data()),
+            output_name = output_name)$mapping,
           function(selector) unname(selector$variables)
         )
       }
@@ -248,7 +251,7 @@ merge_srv <- function(id,
   checkmate::assert_string(join_fun)
 
   # Early validation of merge keys between datasets
-  merge_summary <- .merge_summary_list(selectors, join_keys = teal.data::join_keys(x))
+  merge_summary <- .merge_summary_list(selectors, join_keys = teal.data::join_keys(x), output_name = output_name)
 
   expr <- .merge_expr(merge_summary = merge_summary, output_name = output_name, join_fun = join_fun, x = x)
 
@@ -331,7 +334,7 @@ merge_srv <- function(id,
         list(
           str2lang(join_fun),
           y = this_call,
-          by = join_keys["anl", dataname],
+          by = join_keys[output_name, dataname],
           suffix = c("", sprintf("_%s", dataname))
         )
       )
@@ -355,7 +358,7 @@ merge_srv <- function(id,
 #' - join_keys (`join_keys`) updated `join_keys` containing keys of `ANL`
 #'
 #' @keywords internal
-.merge_summary_list <- function(selectors, join_keys) {
+.merge_summary_list <- function(selectors, join_keys, output_name) {
   checkmate::assert_list(selectors, "picks")
   checkmate::assert_class(join_keys, "join_keys")
 
@@ -415,7 +418,7 @@ merge_srv <- function(id,
         function(dataset_2) {
           new_keys <- join_keys[dataname, dataset_2]
           # ↓ 2. foreign keys of current dataset are added to anl join_keys but only if no relation from anl already
-          if (length(new_keys) && !dataset_2 %in% names(join_keys[["anl"]])) {
+          if (length(new_keys) && !dataset_2 %in% names(join_keys[[output_name]])) {
             # ↓ 3. foreign keys should be renamed if duplicated with anl colnames
             new_key_names <- .suffix_duplicated_vars(
               vars = names(new_keys), # names because we change the key of dataset_1 (not dataset_2)
@@ -423,7 +426,7 @@ merge_srv <- function(id,
               suffix = dataname
             )
             names(new_keys) <- new_key_names
-            teal.data::join_key(dataset_1 = "anl", dataset_2 = dataset_2, keys = new_keys)
+            teal.data::join_key(dataset_1 = output_name, dataset_2 = dataset_2, keys = new_keys)
           }
         }
       )
@@ -443,7 +446,7 @@ merge_srv <- function(id,
 
       # if foreign key of this dataset is selected and if this foreign key took a part in the merge
       #  then this key is dropped and we need to refer to the first variable
-      existing_fk <- join_keys[dataname, "anl"] # keys that are already in anl
+      existing_fk <- join_keys[dataname, output_name] # keys that are already in anl
       existing_fk_selected <- intersect(names(existing_fk), x$variables)
       new_vars[existing_fk_selected] <- existing_fk[existing_fk_selected]
       x$variables <- new_vars
@@ -454,7 +457,7 @@ merge_srv <- function(id,
     this_colnames <- unique(unlist(lapply(mapping_ds, `[[`, "variables")))
     anl_colnames <- c(anl_colnames, this_colnames)
 
-    anl_colnames <- union(anl_colnames, .fk(join_keys, "anl"))
+    anl_colnames <- union(anl_colnames, .fk(join_keys, output_name))
   }
 
   list(mapping = mapping, join_keys = join_keys)

--- a/man/dot-merge_summary_list.Rd
+++ b/man/dot-merge_summary_list.Rd
@@ -4,7 +4,7 @@
 \alias{.merge_summary_list}
 \title{Analyse selectors and concludes a merge parameters}
 \usage{
-.merge_summary_list(selectors, join_keys)
+.merge_summary_list(selectors, join_keys, output_name)
 }
 \value{
 list containing:

--- a/tests/testthat/test-module_merge.R
+++ b/tests/testthat/test-module_merge.R
@@ -204,7 +204,7 @@ testthat::describe("merge_srv returns list with data (teal_data with anl) and va
     )
     checkmate::expect_class(out$data(), "teal_data")
     testthat::expect_setequal(names(out$data()), c("abcd", names(data)))
-    testthat::expect_setequal(names(join_keys(out$data())), c("abcd", names(data)))
+    testthat::expect_setequal(names(teal.data::join_keys(out$data())), c("abcd", names(data)))
   })
 
   it("$data() returns teal_data with merged anl using join_fun", {

--- a/tests/testthat/test-module_merge.R
+++ b/tests/testthat/test-module_merge.R
@@ -180,24 +180,31 @@ testthat::describe("merge_srv returns list with data (teal_data with anl) and va
     checkmate::expect_class(out$data, "reactive")
   })
 
-  it("$data returns reactive containing teal_data with object `output_name`", {
+
+  it("$data returns reactive containing teal_data with keys on `output_name`", {
     shiny::reactiveConsole(TRUE)
     on.exit(reactiveConsole(FALSE))
     data <- teal.data::teal_data()
     data <- within(data, {
       adsl <- data.frame(studyid = "A", usubjid = c("1", "2"), age = c(30, 40))
+      adae <- data.frame(studyid = "A", usubjid = c("1", "2"), other = c("A", "B"))
     })
     teal.data::join_keys(data) <- teal.data::join_keys(
-      teal.data::join_key("adsl", "adsl", c("studyid", "usubjid"))
+      teal.data::join_key("adsl", "adsl", c("studyid", "usubjid")),
+      teal.data::join_key("adsl", "adae", c("studyid", "usubjid"))
     )
 
-    selectors <- list(a = shiny::reactive(picks(datasets("adsl", "adsl"), variables("age", "age"))))
+    selectors <- list(
+      a = shiny::reactive(picks(datasets("adsl", "adsl"), variables("age", "age"))),
+      b = shiny::reactive(picks(datasets("adae", "adae"), variables("other", "other")))
+    )
     out <- shiny::withReactiveDomain(
       domain = shiny::MockShinySession$new(),
       expr = merge_srv(id = "test", data = shiny::reactive(data), selectors = selectors, output_name = "abcd")
     )
     checkmate::expect_class(out$data(), "teal_data")
-    testthat::expect_named(out$data(), c("abcd", "adsl"))
+    testthat::expect_setequal(names(out$data()), c("abcd", names(data)))
+    testthat::expect_setequal(names(join_keys(out$data())), c("abcd", names(data)))
   })
 
   it("$data() returns teal_data with merged anl using join_fun", {


### PR DESCRIPTION
# Pull Request

Closes #101

Adds a new parameter to `.merge_summary_list()` so that the keys can be correctly assigned to the right variable.
This is important if the output is assigned to something different than "anl".
