### PR TITLE
Uses exact "label" attribute to avoid fallbacks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 * Fixed `variables` selection popup to show "Select all"/"Deselect all" when multiple selection is enabled.
 * Adds assertion to check for specific elements of picks to API.
 
+### Bug fixes
+
+* Fixed warning appearing when labels attribute being used in datasets.
+
 # teal.picks 0.2.0
 
 ### Bug fixes

--- a/R/module_picks.R
+++ b/R/module_picks.R
@@ -266,7 +266,7 @@ picks_srv.picks <- function(id, picks, data) {
           choices(),
           function(choice) {
             icon <- toString(icon(.picker_icon(data()[[choice]]), lib = "font-awesome"))
-            label <- attr(data()[[choice]], "label")
+            label <- attr(data()[[choice]], "label", exact = TRUE)
             paste(
               icon,
               choice,

--- a/R/resolver.R
+++ b/R/resolver.R
@@ -191,7 +191,7 @@ determine.values <- function(x, data) {
     labels <- vapply(
       out,
       FUN = function(choice) {
-        label <- attr(data[[choice]], "label")
+        label <- attr(data[[choice]], "label", exact = TRUE)
         if (checkmate::test_string(label)) {
           label
         } else {

--- a/tests/testthat/test-module_picks.R
+++ b/tests/testthat/test-module_picks.R
@@ -1190,3 +1190,26 @@ describe("picks_ui creates different ui depending on choices length and attribut
     expect_false(grepl("fixed-picks", as.character(ui_output)))
   })
 })
+
+test_that("(regression) Labels attribute should not be matched", {
+  withr::local_options(list(warnPartialMatchAttr = TRUE))
+
+  test_picks <- picks(
+    datasets("iris", "iris"),
+    variables(c("Species", "Sepal.Length"))
+  )
+
+  # Edge case that ensures that no other attribute than the label is matched
+  #  This will occur with CO2 dataset without any modifications
+  local_iris <- iris
+  attr(local_iris, "labels") <- "iris dataset"
+  expect_no_warning(
+    shiny::testServer(
+      picks_srv,
+      args = list(id = "test", picks = test_picks, data = shiny::reactive(list(iris = local_iris))),
+      expr = {
+        session$returned()
+      }
+    )
+  )
+})


### PR DESCRIPTION
# Pull Request

- Fixes https://github.com/insightsengineering/teal.picks/issues/96

### Changes description

- When using CO2 dataset in `testthat` it throws a warning because the exact attribute is not used